### PR TITLE
Bug : 상세페이지 새로고침 시 에러 발생 해결

### DIFF
--- a/src/context/ProductsContext.js
+++ b/src/context/ProductsContext.js
@@ -3,27 +3,26 @@ import { getProductJsonData } from "utils/getProductJsonData";
 
 export const AllProductsContext = React.createContext([]);
 
+export const getProducts = async () => {
+  const productJson = await getProductJsonData();
+
+  const editedProductData = productJson.map((item, idx) => {
+    item.id = idx;
+    item.disLike = 0;
+    item.visitedDate = "";
+    return item;
+  });
+
+  return editedProductData;
+};
+
 const ProductsContext = ({ children }) => {
   const [allProducts, setAllProducts] = useState([]);
 
   useEffect(() => {
-    const getProducts = async () => {
-      const productJson = await getProductJsonData();
-
-      const editedProductData = productJson.map((item, idx) => {
-        item.id = idx;
-        item.disLike = 0;
-        item.visitedDate = "";
-        return item;
-      });
-
-      setAllProducts(editedProductData);
-      // return editedProductData;
-    };
-
-    // getProducts().then((products) => {
-    //   setAllProducts(products);
-    // });
+    getProducts().then((products) => {
+      setAllProducts(products);
+    });
     getProducts();
   }, []);
 

--- a/src/pages/ProductDetail.jsx
+++ b/src/pages/ProductDetail.jsx
@@ -5,7 +5,7 @@ import ProductImage from "components/productDetail/ProductImage";
 import Button from "components/common/Button";
 import close from "assets/svg/close.svg";
 import refresh from "assets/svg/refresh.svg";
-import { AllProductsContext } from "context/ProductsContext";
+import { AllProductsContext, getProducts } from "context/ProductsContext";
 import { getVisitedProducts, setVisitedProducts } from "utils/localStorage";
 
 class ProductDetail extends Component {
@@ -14,6 +14,7 @@ class ProductDetail extends Component {
 
     this.state = {
       product: {},
+      allProducts: [],
     };
   }
 
@@ -37,12 +38,25 @@ class ProductDetail extends Component {
     const { match } = this.props;
     const allProducts = this.context;
 
-    this.setState(
-      {
-        product: allProducts[match.params.id],
-      },
-      () => this.setVisitedItemToStorage()
-    );
+    if (allProducts.length) {
+      this.setState(
+        {
+          product: allProducts[match.params.id],
+          allProducts,
+        },
+        () => this.setVisitedItemToStorage()
+      );
+    } else {
+      getProducts().then((allProducts) =>
+        this.setState(
+          {
+            product: allProducts[match.params.id],
+            allProducts,
+          },
+          () => this.setVisitedItemToStorage()
+        )
+      );
+    }
   }
 
   handleDisLikeClick = () => {
@@ -56,8 +70,8 @@ class ProductDetail extends Component {
   };
 
   handleRandomClick = () => {
-    const { product } = this.state;
-    const allProducts = this.context;
+    const { product, allProducts } = this.state;
+    // const allProducts = this.context;
     const randomNum = Math.floor(Math.random() * (allProducts.length - 1));
     const { disLike } = allProducts[randomNum];
 
@@ -65,10 +79,15 @@ class ProductDetail extends Component {
       this.handleRandomClick();
     }
 
+    const item = allProducts[randomNum];
+    if (item?.title === undefined) {
+      console.log("id", item.id);
+    }
     this.setState(
-      {
+      (prev) => ({
+        ...prev,
         product: allProducts[randomNum],
-      },
+      }),
       () => this.setVisitedItemToStorage()
     );
 

--- a/src/utils/getProductJsonData.js
+++ b/src/utils/getProductJsonData.js
@@ -1,5 +1,5 @@
 export const getProductJsonData = async () => {
-  const response = await fetch("data/data.json");
+  const response = await fetch("http://localhost:3000/data/data.json");
   const data = await response.json();
   return data;
 };


### PR DESCRIPTION
상세 페이지 새로고침 시 발생하는 에러 원인:
context컴포넌트가 새로 만들어지면서 context값(allProducts)도 새로 할당되어 사용할 수 있을거라 생각했지만 그렇지 않았다.
새로고침 시 context값이 [] 로 나온다.

해결 방법:
ProductDetail 페이지 컴포넌트가 랜더링 될 때 this.context값이 빈 배열값이면 전체 상품 데이터 request요청을 보내 전체 상품 데이터를 불러오는 방법으로 해결
```js
const allProducts = this.context;
if (allProducts.length) {
      // context값이 있는 경우
      this.setState(
        {
          product: allProducts[match.params.id],
          allProducts,
        },
        () => this.setVisitedItemToStorage()
      );
    } else {
      // context값이 없는 경우
      getProducts().then((allProducts) =>
        this.setState(
          {
            product: allProducts[match.params.id],
            allProducts,
          },
          () => this.setVisitedItemToStorage()
        )
      );
    }
```

